### PR TITLE
Fix outdated profiler debug panel tab

### DIFF
--- a/ajax/profiler.php
+++ b/ajax/profiler.php
@@ -1,0 +1,12 @@
+<?php
+
+include('../../../inc/includes.php');
+
+Session::checkLoginUser();
+
+if ($_SESSION['glpi_use_mode'] !== Session::DEBUG_MODE) {
+   return;
+}
+Session::checkRight(Config::$rightname, UPDATE);
+
+PluginDevProfiler::showDebugTab();

--- a/js/dev.js
+++ b/js/dev.js
@@ -359,6 +359,22 @@ class GlpiDevProfiler extends GlpiDevView {
         filter_toggles.on('click', () => {
             this.refreshFilters();
         });
+        const debug_panel_container = $('div.debug-panel #devprofiler-container');
+        if (debug_panel_container.length > 0) {
+            // Add listener for when the profiler tab is shown
+            const tab_pane = debug_panel_container.closest('.tab-pane').attr('id');
+            const tab_link = $('a[href="#' + tab_pane + '"]');
+            tab_link.on('shown.bs.tab', () => {
+                $.ajax({
+                    'url': this.ajax_root + 'profiler.php',
+                    'method': 'GET',
+                }).then((result) => {
+                    if (result) {
+                        debug_panel_container.replaceWith($(result));
+                    }
+                });
+            });
+        }
     }
 
     static refreshFilters() {


### PR DESCRIPTION
Profiler sections are dumped during script shutdown which is after the debug panel tab is loaded. This PR updates the profiler debug panel tab each time the tab is shown to help make sure it is up to date for the main request and be updated for any background AJAX requests (if you navigate to another tab and then back to it).